### PR TITLE
Default database and using connection.url

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This means you can have fine-grained control over your schema/data transformatio
 
 sails-migrations supports sails versions 0.9X up to 0.10.5, for both MySQL & PostgreSQL.
 
-Please let us know if you encounter any problem working with sails-migrations by 
+Please let us know if you encounter any problem working with sails-migrations by
 opening an issue.
 
 As of version 2.0 we've moved to using knex schema builder.
@@ -54,7 +54,7 @@ Fairly simple, there are a few basic commands
 
 ## Example apps
 
-You can checkout some [example Sails apps](https://github.com/BlueHotDog/sails-migrations/tree/master/samples).
+You can checkout some [example Sails apps](https://github.com/BlueHotDog/sails-migrations/tree/master/test/fixtures/sample_apps).
 
 ## Commands
 

--- a/lib/sails-migrations/helpers/config_loader.js
+++ b/lib/sails-migrations/helpers/config_loader.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const url = require('url');
 const _ = require('lodash');
 const Promise = require('bluebird');
 const SailsIntegration = require('./sails_integration');
@@ -45,7 +46,14 @@ function getConfigFromSailsConfig(sailsConfig) {
 
 function getConnectionFromSailsConfig(sailsConfig) {
   if (typeof sailsConfig.defaultAdapter.config.url !== 'undefined' && sailsConfig.defaultAdapter.config.url !== null) {
-    return sailsConfig.defaultAdapter.config.url;
+    var dbUrl = url.parse(sailsConfig.defaultAdapter.config.url);
+    return {
+      host: dbUrl.hostname,
+      user: dbUrl.auth.split(':')[0],
+      port: dbUrl.port,
+      database: dbUrl.path.slice(1),
+      password: dbUrl.auth.split(':')[1]
+    }
   } else {
     const fullConfig = _.defaults({}, sailsConfig.defaultAdapter.config, sailsConfig.defaultAdapter.defaults);
     return {

--- a/lib/sails-migrations/helpers/database_tasks.js
+++ b/lib/sails-migrations/helpers/database_tasks.js
@@ -5,13 +5,18 @@ const errors = require('../errors');
 const PG_CLIENT_NAME = 'pg';
 const MYSQL_CLIENT_NAME = 'mysql';
 
+const clientToDefaultDbTable = {
+  'pg': 'postgres',
+  'mysql': 'mysql'
+}
+
 function DatabaseTasks() {}
 
 
 DatabaseTasks.executeQuery = function (config, query, cb) {
   //config.debug = true;
   database = config.connection.database
-  config.connection.database = undefined; //bug in knex, if you pass a db, it will fail to drop/create a db :-(
+  config.connection.database = clientToDefaultDbTable[config.client]; //bug in knex, if you pass a db, it will fail to drop/create a db :-(
   var knex = require('knex')(config);
   knex.raw(query).then(cb, cb)
 };


### PR DESCRIPTION
There is not always a database for the logged in user; instead we can use tables that will always be available for mysql / postgres.

When specifying a sails connection with url, there are problems in the database_tasks.js file because config.connection.database is expected (due to the knex issue passing in a database for drop/create). Instead we can parse the connection.url to get back to a simple case of expected config attrs.

Also updating the README.md for where the sample_apps are at.