### PR TITLE
Fix incorrect quote marks to escape db names

### DIFF
--- a/lib/sails-migrations/helpers/database_tasks.js
+++ b/lib/sails-migrations/helpers/database_tasks.js
@@ -10,6 +10,12 @@ const clientToDefaultDbTable = {
   'mysql': 'mysql'
 }
 
+function escapeIdentifier(config, identifier) {
+  var escapeChar = config.client == MYSQL_CLIENT_NAME ? "`" : "\"";
+
+  return escapeChar + identifier + escapeChar;
+}
+
 function DatabaseTasks() {}
 
 
@@ -31,7 +37,8 @@ DatabaseTasks.executeQuery = function (config, query, cb) {
  * */
 DatabaseTasks.create = function (config, cb) {
   var database = config.connection.database;
-  DatabaseTasks.executeQuery(config, "CREATE DATABASE \"" + database + "\"", function (err, stdout, stdin) {
+
+  DatabaseTasks.executeQuery(config, "CREATE DATABASE " + escapeIdentifier(config, database), function (err, stdout, stdin) {
     config.connection.database = database;
     if (err instanceof Error){
       cb(err, config);
@@ -51,7 +58,7 @@ DatabaseTasks.create = function (config, cb) {
  * */
 DatabaseTasks.drop = function (config, cb) {
   var database = config.connection.database;
-  DatabaseTasks.executeQuery(config, "DROP DATABASE \"" + database + "\"", function (err, stdout, stdin) {
+  DatabaseTasks.executeQuery(config, "DROP DATABASE " + escapeIdentifier(config, database), function (err, stdout, stdin) {
     config.connection.database = database;
     if (err instanceof Error){
       cb(err, config);


### PR DESCRIPTION
The correct escaping character for database names in MySQL is backtick (`) unless the ANSI_QUOTES mode is enabled. In any case backtick works so it is safer to use it for MySQL.

See: https://dev.mysql.com/doc/refman/5.0/en/identifiers.html

Fixes #60 