### PR TITLE
load rc so that environment variables are processed

### DIFF
--- a/lib/sails-migrations/helpers/sails_integration.js
+++ b/lib/sails-migrations/helpers/sails_integration.js
@@ -24,11 +24,13 @@ SailsIntegration.loadSailsConfig = function (modulesPath, cb) {
 
   if (cache) { return cb(null, cache); }
 
-  options = {
+  var rconf = require(path.join(sailsPath(modulesPath),'/lib/app/configuration/rc'));
+
+  options = _.merge(rconf,{
     globals:   false,
     loadHooks: ['moduleloader', 'userconfig'],
     appPath:   path.join(modulesPath, "..")
-  };
+  });
 
   sails = require(sailsPath(modulesPath));
   return sails.load(options, function (err) {

--- a/lib/sails-migrations/helpers/sails_integration.js
+++ b/lib/sails-migrations/helpers/sails_integration.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const semver = require('semver');
 const _ = require('lodash');
 
 function getSailsVersion(sailsObject) {
@@ -30,9 +29,14 @@ SailsIntegration.loadSailsConfig = function (modulesPath, cb) {
   var sailsPathStr = sailsPath(modulesPath);
   var sailsPackage = require(path.join(sailsPathStr,'package'));
 
-  var rconf = semver.gte(sailsPackage.version,'0.10.0') 
-    ? require(path.join(sailsPathStr,'/lib/app/configuration/rc'))
-    : {};
+  var rconf;
+  try {
+    rconf = require(path.join(sailsPathStr,'/lib/app/configuration/rc'));
+  }
+  catch(e) {
+    // If rc does not exist then set to empty object
+    rconf = {};
+  }
 
   options = _.merge(rconf,{
     globals:   false,

--- a/lib/sails-migrations/helpers/sails_integration.js
+++ b/lib/sails-migrations/helpers/sails_integration.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const semver = require('semver');
 const _ = require('lodash');
 
 function getSailsVersion(sailsObject) {
@@ -24,7 +25,12 @@ SailsIntegration.loadSailsConfig = function (modulesPath, cb) {
 
   if (cache) { return cb(null, cache); }
 
-  var rconf = require(path.join(sailsPath(modulesPath),'/lib/app/configuration/rc'));
+  var sailsPathStr = sailsPath(modulesPath);
+  var sailsPackage = require(path.join(sailsPathStr,'package'));
+
+  var rconf = semver.gte(sailsPackage.version,'0.10.0') 
+    ? require(path.join(sailsPathStr,'/lib/app/configuration/rc'))
+    : {};
 
   options = _.merge(rconf,{
     globals:   false,
@@ -32,7 +38,7 @@ SailsIntegration.loadSailsConfig = function (modulesPath, cb) {
     appPath:   path.join(modulesPath, "..")
   });
 
-  sails = require(sailsPath(modulesPath));
+  sails = require(sailsPathStr);
   return sails.load(options, function (err) {
     if (err) { return cb(err); }
     cache = SailsIntegration.getSailsConfig(modulesPath, sails);

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "liftoff": "1.0.4",
     "lodash": "2.4",
     "optimist": "0.6.1",
-    "semver": "^4.3.6",
     "tildify": "1.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "liftoff": "1.0.4",
     "lodash": "2.4",
     "optimist": "0.6.1",
+    "semver": "^4.3.6",
     "tildify": "1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Sails `load` does not run the [rc](https://github.com/balderdashy/sails/blob/master/lib/app/configuration/rc.js) loader.  There is a [TODO](https://github.com/balderdashy/sails/blob/master/lib/app/configuration/load.js#L50) to add it.

Until that day comes, it is done in [lift](https://github.com/balderdashy/sails/blob/master/bin/sails-lift.js) by adding rconf to the option scope. 

If sails-migration can load `rc` and merge the options then all configuration including the environment will be processed as intended.