### PR TITLE
Fix usage for Node 6 and Sails 0.12

### DIFF
--- a/lib/sails-migrations/helpers/config_loader.js
+++ b/lib/sails-migrations/helpers/config_loader.js
@@ -17,7 +17,7 @@ function getModulesPath(basePath) {
 function getClientFromSailsConfig(sailsConfig) {
   var version = sailsConfig.defaultAdapter.version;
   var adapter;
-  if (version === '0.10' || version === '0.11') {
+  if (_.contains(["0.10", "0.11", "0.12"], version)) {
     adapter = sailsConfig.defaultAdapter.config.adapter;
   } else if (version === '0.9') {
     adapter = sailsConfig.defaultAdapter.identity;

--- a/lib/sails-migrations/helpers/sails_integration.js
+++ b/lib/sails-migrations/helpers/sails_integration.js
@@ -49,7 +49,7 @@ SailsIntegration.getSailsConfig = function (modulesPath, sails) {
       dbConfig = sails.config.adapters[defaultAdapterName];
       moduleName = dbConfig.module;
       break;
-    case sailsVersion === "0.10" || sailsVersion === "0.11":
+    case _.contains(["0.10", "0.11", "0.12"], sailsVersion):
       defaultAdapterName = sails.config.models.connection;
       dbConfig = sails.config.connections[defaultAdapterName];
       moduleName = dbConfig.adapter;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "commander": "2.6.0",
     "interpret": "0.3.7",
     "knex": "0.9.0",
-    "liftoff": "1.0.4",
+    "liftoff": "^2.2.1",
     "lodash": "2.4",
     "optimist": "0.6.1",
     "tildify": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/BlueHotDog/sails-migrations",
   "optionalDependencies": {
-    "pg": "4.1.1",
+    "pg": "4.5.5",
     "mysql": "2.5.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "cli-table": "0.3.1",
     "commander": "2.6.0",
     "interpret": "0.3.7",
-    "knex": "0.9.0",
+    "knex": "^0.11.3",
     "liftoff": "^2.2.1",
     "lodash": "2.4",
     "optimist": "0.6.1",


### PR DESCRIPTION
When using this with Node 6.1.0, I started getting:

```
sails-migrations "status"
.../node_modules undefined
path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.join (path.js:1211:7)
    at Function.SailsIntegration.getSailsConfig...
```

Updating liftoff did the trick.

While I was at it, I also noticed the configs for Sails 0.12 weren't being picked up properly. So I fixed that as well :)

Finally, there was a password authentication issue on [node-postgres](https://github.com/brianc/node-postgres/issues/1000) caused by Node 6. Taking https://github.com/tgriesser/knex/pull/1372 as a reference, I upgraded its version to 4.5.5, thus fixing the issue.