### PR TITLE
Parse querystring if using url connection method

### DIFF
--- a/lib/sails-migrations/helpers/config_loader.js
+++ b/lib/sails-migrations/helpers/config_loader.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const url = require('url');
+const querystring = require('querystring');
 const _ = require('lodash');
 const Promise = require('bluebird');
 const SailsIntegration = require('./sails_integration');
@@ -45,12 +46,14 @@ function getConfigFromSailsConfig(sailsConfig) {
 function getConnectionFromSailsConfig(sailsConfig) {
   if (typeof sailsConfig.defaultAdapter.config.url !== 'undefined' && sailsConfig.defaultAdapter.config.url !== null) {
     var dbUrl = url.parse(sailsConfig.defaultAdapter.config.url);
+    var dbUrlQuery = querystring.parse(dbUrl.query) || {};
     return {
       host: dbUrl.hostname,
       user: dbUrl.auth.split(':')[0],
       port: dbUrl.port,
-      database: dbUrl.path.slice(1),
-      password: dbUrl.auth.split(':')[1]
+      database: dbUrl.pathname.slice(1),
+      password: dbUrl.auth.split(':')[1],
+      ssl: dbUrlQuery.ssl === 'true' || false
     }
   } else {
     const fullConfig = _.defaults({}, sailsConfig.defaultAdapter.config, sailsConfig.defaultAdapter.defaults);


### PR DESCRIPTION
For Issue #78 
- Added querystring parse if there are any query's provided in the url to support ?ssl=true/false option.
- Switched to use pathname instead of path to avoid including the ?ssl=true in the database name
