### PR TITLE
config_loader: Support ssl when an url is used

### DIFF
--- a/lib/sails-migrations/helpers/config_loader.js
+++ b/lib/sails-migrations/helpers/config_loader.js
@@ -43,6 +43,8 @@ function getConfigFromSailsConfig(sailsConfig) {
 }
 
 function getConnectionFromSailsConfig(sailsConfig) {
+  const fullConfig = _.defaults({}, sailsConfig.defaultAdapter.config, sailsConfig.defaultAdapter.defaults);
+
   if (typeof sailsConfig.defaultAdapter.config.url !== 'undefined' && sailsConfig.defaultAdapter.config.url !== null) {
     var dbUrl = url.parse(sailsConfig.defaultAdapter.config.url);
     return {
@@ -50,10 +52,10 @@ function getConnectionFromSailsConfig(sailsConfig) {
       user: dbUrl.auth.split(':')[0],
       port: dbUrl.port,
       database: dbUrl.path.slice(1),
-      password: dbUrl.auth.split(':')[1]
+      password: dbUrl.auth.split(':')[1],
+      ssl: fullConfig.ssl || false
     }
   } else {
-    const fullConfig = _.defaults({}, sailsConfig.defaultAdapter.config, sailsConfig.defaultAdapter.defaults);
     return {
       host: fullConfig.host,
       user: fullConfig.user,


### PR DESCRIPTION
We ran into this issue while trying to deploy to heroku, which requires ssl for the connection.

Please let me know if this changeset is sufficient or whether you see a simple way to update the existing tests.