### PR TITLE
Updated PG dependency to latest version to fix security vulerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/BlueHotDog/sails-migrations",
   "optionalDependencies": {
-    "pg": "4.5.5",
+    "pg": "7.4.1",
     "mysql": "2.5.4"
   },
   "dependencies": {


### PR DESCRIPTION
The PG module used has a "critical" security flaw in and shouldn't be depended on any more