### PR TITLE
fix sails-migration generate command error when using sails version 1.0

### DIFF
--- a/lib/sails-migrations/helpers/config_loader.js
+++ b/lib/sails-migrations/helpers/config_loader.js
@@ -21,6 +21,8 @@ function getClientFromSailsConfig(sailsConfig) {
     adapter = sailsConfig.defaultAdapter.config.adapter;
   } else if (version === '0.9') {
     adapter = sailsConfig.defaultAdapter.identity;
+  } else if (version === '1.0') {
+    adapter = sailsConfig.defaultAdapter.identity;
   }
   return sailsToKnexClient[adapter];
 }

--- a/lib/sails-migrations/helpers/sails_integration.js
+++ b/lib/sails-migrations/helpers/sails_integration.js
@@ -65,6 +65,10 @@ SailsIntegration.getSailsConfig = function (modulesPath, sails) {
       defaultAdapterName = sails.config.models.connection;
       dbConfig = sails.config.connections[defaultAdapterName];
       moduleName = dbConfig.adapter;
+    case sailsVersion === "1.0":
+      defaultAdapterName = sails.config.models.connection;
+      dbConfig = sails.config.datastores.default;
+      moduleName = dbConfig.adapter;
   }
   adapter = require(path.join(modulesPath, moduleName));
   adapter.config = dbConfig;


### PR DESCRIPTION
The current version checks sails version explicitly, and it only checks versions under 1.0. 

Here version 1.0 is added.

This patch is only to solve the issue with "generate" command. Not sure if this is enough to use sails-migration with sails 1.0. 

Hopefully that is the only hard code version checking in the code.